### PR TITLE
fix: Treeland crashes when client exits

### DIFF
--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -942,14 +942,15 @@ void Helper::setActivateSurface(WToplevelSurface *newActivate)
 
     qCDebug(HelperDebugLog) << "Surface: " << newActivate << " is activated";
 
-    invalidCheck =
-        connect(newActivate, &WToplevelSurface::aboutToBeInvalidated, this, [newActivate, this] {
-            newActivate->setActivate(false);
-            setActivateSurface(nullptr);
-        });
-
-    if (newActivate)
+    if (newActivate){
+        invalidCheck =
+            connect(newActivate, &WToplevelSurface::aboutToBeInvalidated, this, [newActivate, this] {
+                newActivate->setActivate(false);
+                setActivateSurface(nullptr);
+            });
         newActivate->setActivate(true);
+    }
+
     Q_EMIT activatedSurfaceChanged();
 }
 


### PR DESCRIPTION
The terminal runs test-window-bg, which should crash due to a null pointer when exiting.