### PR TITLE
fix: move layer surface out of non-root FocusScope

### DIFF
--- a/src/qml/StackWorkspace.qml
+++ b/src/qml/StackWorkspace.qml
@@ -120,25 +120,6 @@ FocusScope {
         }
 
         DynamicCreatorComponent {
-            id: layerComponent
-            creator: Helper.surfaceCreator
-            chooserRole: "type"
-            chooserRoleValue: "layerShell"
-            autoDestroy: false
-
-            onObjectRemoved: function (obj) {
-                obj.doDestroy()
-            }
-
-            LayerSurface {
-                id: layerSurface
-                creatorCompoment: layerComponent
-                activeOutputItem: activeOutputDelegate
-                focus: Helper.activatedSurface === this.waylandSurface
-            }
-        }
-
-        DynamicCreatorComponent {
             id: inputPopupComponent
             creator: Helper.surfaceCreator
             chooserRole: "type"
@@ -152,7 +133,25 @@ FocusScope {
                 shellSurface: popupSurface
             }
         }
+    }
 
+    DynamicCreatorComponent {
+        id: layerComponent
+        creator: Helper.surfaceCreator
+        chooserRole: "type"
+        chooserRoleValue: "layerShell"
+        autoDestroy: false
+
+        onObjectRemoved: function (obj) {
+            obj.doDestroy()
+        }
+
+        LayerSurface {
+            id: layerSurface
+            creatorCompoment: layerComponent
+            activeOutputItem: activeOutputDelegate
+            focus: Helper.activatedSurface === this.waylandSurface
+        }
     }
 
     Item {


### PR DESCRIPTION
log: layer surface is not part of workspace and should not hide when desktop preview

之前为了修焦点改的，不过这个应该可以回退 @justforlxz 