### PR TITLE
fix: Alt+Key_Left or Key_Right display WindowsSwitcher

### DIFF
--- a/src/qml/StackWorkspace.qml
+++ b/src/qml/StackWorkspace.qml
@@ -530,6 +530,24 @@ FocusScope {
             }
         }
     }
+
+    Connections {
+        target: Helper
+        function onSwitcherActiveSwitch(mode) {
+            if (!switcher.visible)
+                return
+
+            switch (mode) {
+            case (Helper.Next):
+                switcher.next()
+                break
+            case (Helper.Previous):
+                switcher.previous()
+                break
+            }
+        }
+    }
+
     Connections {
         target: QmlHelper.shortcutManager
         function onMultitaskViewToggled() {

--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -838,7 +838,7 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *watched, QInputEvent *even
     case Qt::Key_Right: {
         if (event->type() == QEvent::KeyPress) {
             if (m_switcherEnabled) {
-                Q_EMIT switcherChanged(Switcher::Next);
+                Q_EMIT switcherActiveSwitch(Switcher::Next);
                 return true;
             }
         }
@@ -846,7 +846,7 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *watched, QInputEvent *even
     case Qt::Key_Left: {
         if (event->type() == QEvent::KeyPress) {
             if (m_switcherEnabled) {
-                Q_EMIT switcherChanged(Switcher::Previous);
+                Q_EMIT switcherActiveSwitch(Switcher::Previous);
                 return true;
             }
         }

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -182,6 +182,7 @@ Q_SIGNALS:
     void rightExclusiveMarginChanged();
     void socketFileChanged();
     void switcherChanged(Switcher action);
+    void switcherActiveSwitch(Switcher action);
     void switcherOnChanged(bool on);
     void compositorChanged();
     void xdgDecorationManagerChanged();


### PR DESCRIPTION
when switcher.visible is false, ignore Key_Right and Key_Left event.

Log: