### PR TITLE
fix: Alt+tab to display no window in workspace

### DIFF
--- a/src/qml/StackWorkspace.qml
+++ b/src/qml/StackWorkspace.qml
@@ -522,14 +522,16 @@ FocusScope {
     Connections {
         target: Helper
         function onSwitcherChanged(mode) {
-            switcher.visible = true // ensure, won't emit event if already visible
-            switch (mode) {
-            case (Helper.Next):
-                switcher.next()
-                break
-            case (Helper.Previous):
-                switcher.previous()
-                break
+            if (QmlHelper.workspaceManager.workspacesById.get(QmlHelper.workspaceManager.layoutOrder.get(Helper.currentWorkspaceId).wsid).surfaces.count > 0) {
+                switcher.visible = true // ensure, won't emit event if already visible
+                switch (mode) {
+                case (Helper.Next):
+                    switcher.next()
+                    break
+                case (Helper.Previous):
+                    switcher.previous()
+                    break
+                }
             }
         }
     }


### PR DESCRIPTION
when there is no window in the workspace, it is
forbidden to use the shortcut key to open the
alt+tab view.

Log: