### PR TITLE
fix: wlr-randr scale not work

### DIFF
--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -192,11 +192,6 @@ void Helper::initProtocols(WOutputRenderWindow *window)
                             }
                         }
                     }
-
-                    if (onlyTest)
-                        ok &= output->test();
-                    else
-                        ok &= output->commit();
                 }
                 outputManager->sendResult(config, ok);
 


### PR DESCRIPTION
drm is pending, commit will fail, case set scale to become invalid, do not commit and wait until the next frame to complete the scaling settings.