### PR TITLE
fix: Window display incomplete

### DIFF
--- a/src/qml/QmlHelper.qml
+++ b/src/qml/QmlHelper.qml
@@ -100,7 +100,7 @@ Item {
         let prevStateStore = restoreStates.get(prevEnvHash)
         for (let i = 0; i < workspaceManager.allSurfaces.count; i++) {
             const surf = workspaceManager.allSurfaces.get(i).wrapper
-            const surfKey = surf.waylandSurface
+            const surfKey = surf.wSurface
             console.debug(`restoring ${surfKey} ${printStructureObject(surf.store?.normal)} => ${printStructureObject(curStateStore.get(surfKey)?.store?.normal)}`)
             let prevStore={t:Date.now()}
             Object.assign(prevStore,surf.store)

--- a/src/qml/SurfaceWrapper.qml
+++ b/src/qml/SurfaceWrapper.qml
@@ -271,14 +271,10 @@ SurfaceItemFactory {
         surfaceItem.state = "default"
     }
     onIsMoveResizingChanged: if (!isMoveResizing) {
-        if (state === "default")
-            saveState()
+        saveState()
     }
     onStoreChanged: {
         storeNormalWidth = store.normal?.width ?? 0
-    }
-    Component.onCompleted: {
-        saveState() // save initial state
     }
 
     ListModel {


### PR DESCRIPTION
Adapt Waylib refactoring and replace WaylandSurface with wSurface. 

When the component is loaded, saveState cannot save the geometry of the actual surfaceItem, resulting in incomplete display of the window during layout recovery.