### PR TITLE
chore: change quit code

### DIFF
--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -863,8 +863,7 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *watched, QInputEvent *even
     if (event->type() == QEvent::KeyPress) {
         auto kevent = static_cast<QKeyEvent *>(event);
         if (QKeySequence(kevent->keyCombination()) == QKeySequence::Quit) {
-            // NOTE: 133 exitcode is reset DDM restart limit.
-            qApp->exit(133);
+            qApp->exit(-1);
             return true;
         }
     }


### PR DESCRIPTION
Exiting using the shortcut key is considered an abnormal exit. DDM will count the number of abnormal exits and will not start treeland afterwards.

Log: