### PR TITLE
chore: code reviwe for `src/utils`(part1)

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -18,6 +18,7 @@ qt_add_qml_module(utils
         logstream.cpp
         tquickradiuseffect.cpp
         tsgradiusimagenode.cpp
+        global.cpp
     RESOURCE_PREFIX
         /qt/qml
     OUTPUT_DIRECTORY
@@ -39,6 +40,7 @@ FILES
     tquickradiuseffect.h
     tquickradiuseffect_p.h
     tsgradiusimagenode.h
+    global.h
 )
 
 target_compile_definitions(utils
@@ -49,6 +51,7 @@ target_compile_definitions(utils
 target_include_directories(utils
     PRIVATE
         ${Qt6Quick_PRIVATE_INCLUDE_DIRS}
+        ${PROJECT_SOURCE_DIR}/src/modules
 )
 
 target_link_libraries(utils

--- a/src/utils/filterproxymodel.cpp
+++ b/src/utils/filterproxymodel.cpp
@@ -38,6 +38,7 @@ void FilterProxyModel::setFilterAcceptsRow(const QJSValue &val)
 {
     if (val.equals(m_filterAcceptsRow))
         return;
+
     m_filterAcceptsRow = val;
     emit filterAcceptsRowChanged();
 }
@@ -55,7 +56,3 @@ void FilterProxyModel::invalidate()
     invalidateFilter();
 }
 
-int FilterProxyModel::count() const
-{
-    return rowCount();
-}

--- a/src/utils/filterproxymodel.h
+++ b/src/utils/filterproxymodel.h
@@ -14,8 +14,6 @@ class FilterProxyModel : public QSortFilterProxyModel
 public:
     explicit FilterProxyModel(QObject *parent = nullptr);
     Q_PROPERTY(QJSValue filterAcceptsRow READ filterAcceptsRow WRITE setFilterAcceptsRow NOTIFY filterAcceptsRowChanged)
-    Q_PROPERTY(int count READ count NOTIFY countChanged)
-    int count() const;
 
     void setFilterAcceptsRow(const QJSValue &val);
     QJSValue filterAcceptsRow() const {

--- a/src/utils/gestures.h
+++ b/src/utils/gestures.h
@@ -13,7 +13,6 @@ class Gesture : public QObject
     Q_OBJECT
 public:
     Gesture(QObject *parent = nullptr);
-    ~Gesture() override;
 
 Q_SIGNALS:
     void started();
@@ -26,7 +25,6 @@ class SwipeGesture : public Gesture
     Q_OBJECT
 public:
     explicit SwipeGesture(QObject *parent = nullptr);
-    ~SwipeGesture() override;
 
     enum Direction {
         Invalid,
@@ -95,7 +93,6 @@ class GestureRecognizer : public QObject
     Q_OBJECT
 public:
     explicit GestureRecognizer(QObject *parent = nullptr);
-    ~GestureRecognizer() override;
 
     enum StartPositionBehavior {
         Relevant,
@@ -107,6 +104,9 @@ public:
         Vertical,
         None,
     };
+
+    Q_ENUM(StartPositionBehavior)
+    Q_ENUM(Axis)
 
     void registerSwipeGesture(SwipeGesture *gesture);
     void unregisterSwipeGesture(SwipeGesture *gesture);

--- a/src/utils/global.cpp
+++ b/src/utils/global.cpp
@@ -1,0 +1,4 @@
+
+#include "global.h"
+
+Q_LOGGING_CATEGORY(utils, "treeland.utils", QtDebugMsg);

--- a/src/utils/global.h
+++ b/src/utils/global.h
@@ -1,0 +1,7 @@
+// Copyright (C) 2024 groveer <guoyao@uniontech.com>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+#pragma once
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(utils);

--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -3,10 +3,11 @@
 
 #include "helper.h"
 
-#include "../modules/foreign-toplevel/foreigntoplevelmanagerv1.h"
-#include "../modules/primary-output/outputmanagement.h"
-#include "../modules/virtual-output/virtualoutputmanager.h"
+#include "foreign-toplevel/foreigntoplevelmanagerv1.h"
+#include "global.h"
 #include "inputdevice.h"
+#include "primary-output/outputmanagement.h"
+#include "virtual-output/virtualoutputmanager.h"
 
 #include <WBackend>
 #include <WForeignToplevel>
@@ -50,6 +51,7 @@
 #include <QAction>
 #include <QFile>
 #include <QGuiApplication>
+#include <QJsonValue>
 #include <QLoggingCategory>
 #include <QMouseEvent>
 #include <QProcess>
@@ -60,8 +62,6 @@
 #include <QQuickStyle>
 #include <QQuickWindow>
 #include <QRegularExpression>
-#include <qjsonvalue.h>
-#include <qobject.h>
 
 #define WLR_FRACTIONAL_SCALE_V1_VERSION 1
 
@@ -70,9 +70,7 @@
 
 #define OUTPUTS_FOOLPROOF_RESERVED_PIXELS 5
 
-Q_LOGGING_CATEGORY(HelperDebugLog, "TreeLand.Helper.Debug", QtDebugMsg);
-
-inline QPointF getItemGlobalPosition(QQuickItem *item)
+static QPointF getItemGlobalPosition(QQuickItem *item)
 {
     auto parent = item->parentItem();
     return parent ? parent->mapToGlobal(item->position()) : item->position();
@@ -104,7 +102,7 @@ void Helper::initProtocols(WOutputRenderWindow *window)
     m_renderer = WRenderHelper::createRenderer(backend->handle());
 
     if (!m_renderer) {
-        qFatal("Failed to create renderer");
+        qCFatal(utils) << "Failed to create renderer";
     }
 
     m_allocator = qw_allocator::autocreate(*backend->handle(), *m_renderer);
@@ -158,7 +156,7 @@ void Helper::initProtocols(WOutputRenderWindow *window)
         setWaylandSocket(m_socket->fullServerName());
     } else {
         delete m_socket;
-        qCritical("Failed to create socket");
+        qCFatal(utils) << "Failed to create socket";
     }
 
     auto *outputManager = m_server->attach<WOutputManagerV1>();
@@ -222,33 +220,27 @@ void Helper::initProtocols(WOutputRenderWindow *window)
             m_surfaceCreator,
             &WQmlCreator::removeByOwner);
 
-    connect(xdgShell,
-            &WXdgShell::surfaceAdded,
-            this,
-            [this, engine](WXdgSurface *surface) {
-                auto initProperties = engine->newObject();
-                auto type = surface->isPopup() ? "popup" : "toplevel";
-                initProperties.setProperty("type", type);
-                initProperties.setProperty("wSurface", engine->toScriptValue(surface));
-                initProperties.setProperty("wid", engine->toScriptValue(workspaceId(engine)));
+    connect(xdgShell, &WXdgShell::surfaceAdded, this, [this, engine](WXdgSurface *surface) {
+        auto initProperties = engine->newObject();
+        auto type = surface->isPopup() ? "popup" : "toplevel";
+        initProperties.setProperty("type", type);
+        initProperties.setProperty("wSurface", engine->toScriptValue(surface));
+        initProperties.setProperty("wid", engine->toScriptValue(workspaceId(engine)));
 
-                m_surfaceCreator->add(surface, initProperties);
+        m_surfaceCreator->add(surface, initProperties);
 
-                if (!surface->isPopup()) {
-                    m_foreignToplevel->addSurface(surface);
-                    m_treelandForeignToplevel->add(surface);
-                }
-            });
+        if (!surface->isPopup()) {
+            m_foreignToplevel->addSurface(surface);
+            m_treelandForeignToplevel->add(surface);
+        }
+    });
     connect(xdgShell, &WXdgShell::surfaceRemoved, m_surfaceCreator, &WQmlCreator::removeByOwner);
-    connect(xdgShell,
-            &WXdgShell::surfaceRemoved,
-            m_foreignToplevel,
-            [this](WXdgSurface *surface) {
-                if (!surface->isPopup()) {
-                    m_foreignToplevel->removeSurface(surface);
-                    m_treelandForeignToplevel->remove(surface);
-                }
-            });
+    connect(xdgShell, &WXdgShell::surfaceRemoved, m_foreignToplevel, [this](WXdgSurface *surface) {
+        if (!surface->isPopup()) {
+            m_foreignToplevel->removeSurface(surface);
+            m_treelandForeignToplevel->remove(surface);
+        }
+    });
 
     connect(layerShell, &WLayerShell::surfaceAdded, this, [this, engine](WLayerSurface *surface) {
         auto initProperties = engine->newObject();
@@ -304,14 +296,16 @@ void Helper::initProtocols(WOutputRenderWindow *window)
                     // TODO: Screen position restoration;
                     // TODO: Continue to improve this algorithm after formulating layout rules
                     if (outputitem->output() != output) {
-                        if (outputitem->x() > output->position().x() && outputitem->y() == output->position().y()) {
-                            outputitem->setX(outputitem->x() -
-                                            WOutputItem::getOutputItem(output)->width());
+                        if (outputitem->x() > output->position().x()
+                            && outputitem->y() == output->position().y()) {
+                            outputitem->setX(outputitem->x()
+                                             - WOutputItem::getOutputItem(output)->width());
                         }
 
-                        if (outputitem->y() > output->position().y() && outputitem->x() == output->position().x()) {
-                            outputitem->setY(outputitem->y() -
-                                            WOutputItem::getOutputItem(output)->height());
+                        if (outputitem->y() > output->position().y()
+                            && outputitem->x() == output->position().x()) {
+                            outputitem->setY(outputitem->y()
+                                             - WOutputItem::getOutputItem(output)->height());
                         }
                     }
                 }
@@ -702,8 +696,10 @@ void Helper::startResize(
 
 void Helper::cancelMoveResize(WSurfaceItem *shell)
 {
-    if (moveReiszeState.surfaceItem != shell)
+    if (moveReiszeState.surfaceItem != shell) {
+        qCWarning(utils) << "cancelMoveResize: surfaceItem is not the same";
         return;
+    }
     stopMoveResize();
 }
 
@@ -910,15 +906,12 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *watched, QInputEvent *even
                 QRectF geo(moveReiszeState.surfacePosOfStartMoveResize,
                            moveReiszeState.surfaceSizeOfStartMoveResize);
 
-                if (moveReiszeState.resizeEdgets & Qt::LeftEdge)
-                    geo.setLeft(geo.left() + increment_pos.x());
-                if (moveReiszeState.resizeEdgets & Qt::TopEdge)
-                    geo.setTop(geo.top() + increment_pos.y());
-
-                if (moveReiszeState.resizeEdgets & Qt::RightEdge)
-                    geo.setRight(geo.right() + increment_pos.x());
-                if (moveReiszeState.resizeEdgets & Qt::BottomEdge)
-                    geo.setBottom(geo.bottom() + increment_pos.y());
+                geo.adjust(
+                    (moveReiszeState.resizeEdgets & Qt::LeftEdge) ? increment_pos.x() : 0,
+                    (moveReiszeState.resizeEdgets & Qt::TopEdge) ? increment_pos.y() : 0,
+                    (moveReiszeState.resizeEdgets & Qt::RightEdge) ? increment_pos.x() : 0,
+                    (moveReiszeState.resizeEdgets & Qt::BottomEdge) ? increment_pos.y() : 0
+                );
 
                 if (moveReiszeState.surfaceItem->resizeSurface(geo.size().toSize()))
                     moveReiszeState.surfaceItem->setPosition(geo.topLeft());
@@ -982,7 +975,6 @@ WToplevelSurface *Helper::activatedSurface() const
 
 void Helper::setActivateSurface(WToplevelSurface *newActivate)
 {
-    qCDebug(HelperDebugLog) << newActivate;
     if (newActivate) {
         wl_client *client = newActivate->surface()->handle()->handle()->resource->client;
         pid_t pid;
@@ -1008,10 +1000,11 @@ void Helper::setActivateSurface(WToplevelSurface *newActivate)
     if (newActivate && newActivate->doesNotAcceptFocus())
         return;
 
+    qCDebug(utils) << "set activate surface" << newActivate;
     if (m_activateSurface && m_activateSurface->isActivated()) {
         if (newActivate) {
-            qCDebug(HelperDebugLog)
-                << "newActivate keyboardFocusPriority " << newActivate->keyboardFocusPriority();
+            qCDebug(utils) << "newActivate keyboardFocusPriority "
+                           << newActivate->keyboardFocusPriority();
             if (m_activateSurface->keyboardFocusPriority() > newActivate->keyboardFocusPriority())
                 return;
         } else {
@@ -1026,7 +1019,7 @@ void Helper::setActivateSurface(WToplevelSurface *newActivate)
 
     m_activateSurface = newActivate;
 
-    qCDebug(HelperDebugLog) << "Surface: " << newActivate << " is activated";
+    qCDebug(utils) << "Surface: " << newActivate << " is activated";
 
     if (newActivate) {
         invalidCheck = connect(newActivate,
@@ -1118,32 +1111,24 @@ WXWayland *Helper::createXWayland()
     m_xwaylands.append(xwayland);
     xwayland->setSeat(m_seat);
 
-    connect(
-        xwayland,
-        &WXWayland::surfaceAdded,
-        this,
-        [this, xwayland](WXWaylandSurface *surface) {
-            QQmlApplicationEngine *engine = qobject_cast<QQmlApplicationEngine *>(qmlEngine(this));
-            surface->safeConnect(
-                &qw_xwayland_surface::notify_associate,
-                this,
-                [this, surface, engine] {
-                    auto initProperties = engine->newObject();
-                    initProperties.setProperty("type", "xwayland");
-                    initProperties.setProperty("wSurface", engine->toScriptValue(surface));
-                    initProperties.setProperty("wid", engine->toScriptValue(workspaceId(engine)));
+    connect(xwayland, &WXWayland::surfaceAdded, this, [this, xwayland](WXWaylandSurface *surface) {
+        QQmlApplicationEngine *engine = qobject_cast<QQmlApplicationEngine *>(qmlEngine(this));
+        surface->safeConnect(&qw_xwayland_surface::notify_associate, this, [this, surface, engine] {
+            auto initProperties = engine->newObject();
+            initProperties.setProperty("type", "xwayland");
+            initProperties.setProperty("wSurface", engine->toScriptValue(surface));
+            initProperties.setProperty("wid", engine->toScriptValue(workspaceId(engine)));
 
-                    m_surfaceCreator->add(surface, initProperties);
-                    m_foreignToplevel->addSurface(surface);
-                    m_treelandForeignToplevel->add(surface);
-                });
-            surface->safeConnect(&qw_xwayland_surface::notify_dissociate, this, [this, surface] {
-                m_surfaceCreator->removeByOwner(surface);
-                m_foreignToplevel->removeSurface(surface);
-                m_treelandForeignToplevel->remove(surface);
-            });
-        }
-    );
+            m_surfaceCreator->add(surface, initProperties);
+            m_foreignToplevel->addSurface(surface);
+            m_treelandForeignToplevel->add(surface);
+        });
+        surface->safeConnect(&qw_xwayland_surface::notify_dissociate, this, [this, surface] {
+            m_surfaceCreator->removeByOwner(surface);
+            m_foreignToplevel->removeSurface(surface);
+            m_treelandForeignToplevel->remove(surface);
+        });
+    });
 
     return xwayland;
 }
@@ -1184,7 +1169,7 @@ QString Helper::clientName(Waylib::Server::WSurface *surface) const
             QString(file.readLine()).section(QRegularExpression("([\\t ]*:[\\t ]*|\\n)"), 1, 1);
     }
 
-    qDebug() << "Program name for PID" << pid << "is" << programName;
+    qCDebug(utils) << "Program name for PID" << pid << "is" << programName;
     return programName;
 }
 

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -98,9 +98,9 @@ public:
     Q_ENUM(WallpaperType)
 
     enum MetaKeyCheck {
-        ShortcutOverride,
-        KeyPress,
-        KeyRelease,
+        ShortcutOverride = 0x1,
+        KeyPress = 0x2,
+        KeyRelease = 0x4,
     };
 
     void initProtocols(WOutputRenderWindow *window);
@@ -128,7 +128,7 @@ public:
     QString waylandSocket() const;
     QString xwaylandSocket() const;
 
-    Q_INVOKABLE QString clientName(Waylib::Server::WSurface *surface) const;
+    Q_INVOKABLE QString clientName(WAYLIB_SERVER_NAMESPACE::WSurface *surface) const;
 
     void stopMoveResize();
 

--- a/src/utils/inputdevice.h
+++ b/src/utils/inputdevice.h
@@ -3,19 +3,23 @@
 
 #pragma once
 
-#include <wglobal.h>
-#include <QObject>
-#include <qwglobal.h>
-#include <QInputDevice>
+#include "gestures.h"
 
 #include <libinput.h>
-#include "gestures.h"
+
+#include <wglobal.h>
+
+#include <qwglobal.h>
+
+#include <QInputDevice>
+#include <QObject>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WInputDevice;
 WAYLIB_SERVER_END_NAMESPACE
 
 WAYLIB_SERVER_USE_NAMESPACE
+
 struct SwipeFeedBack
 {
     SwipeGesture::Direction direction;
@@ -27,14 +31,14 @@ struct SwipeFeedBack
 class InputDevice : public QObject
 {
 public:
-    static InputDevice* instance();
+    static InputDevice *instance();
 
-    InputDevice(const InputDevice&) = delete;
-    InputDevice& operator=(const InputDevice&) = delete;
+    InputDevice(const InputDevice &) = delete;
+    InputDevice &operator=(const InputDevice &) = delete;
 
     bool initTouchPad(WInputDevice *handle);
 
-    void registerTouchpadSwipe(const SwipeFeedBack& feed);
+    void registerTouchpadSwipe(const SwipeFeedBack &feed);
 
     void processSwipeStart(uint finger);
     void processSwipeUpdate(const QPointF &delta);
@@ -45,7 +49,7 @@ private:
     InputDevice(QObject *parent = nullptr);
     ~InputDevice();
 
-    static InputDevice* m_instance;
-    GestureRecognizer* m_touchpadRecognizer;
+    static InputDevice *m_instance;
+    GestureRecognizer *m_touchpadRecognizer;
     uint m_touchpadFingerCount = 0;
 };


### PR DESCRIPTION
- [x] FilterProxyModel中的count属性目前没有地方用到，可移除
- [x] filterproxymodel.cpp:40 这里应该有一行空行
- [x] filterproxymodel.cpp:47 FilterProxyModel的get方法需要检查入参是否是一个有效的index
- [x] gestures.h:103 :109 QObject中的enum需要加上Q_ENUM标记
- [x] gestures.cpp:13 :20 default的构造函数在声明中书写
- [x] gestures.cpp:62 这里不应该有空行
- [x] gestures.cpp:134-135 可以使用QRect的right和bottom方法
- [ ] gestures.cpp:164 确定应该使用std的工具函数还是Qt的工具函数 -> 尽量使用std
- [x] gestures.cpp:246 Axis在这里可能是None，这里不应该是Unreachable
- [x] gestures.cpp:249 不要用魔法数字 -> 已注释
- [x] gestures.cpp:255 :287 这里的static_cast是非必要的
- [x] gestures.cpp:259 这里的格式可以对齐得更均匀些
- [x] gestures.cpp:269 这里的std::as_const看起来没有效果，需要检查一下 -> 使用右值引用后有效果，这里修饰的是指针常量，指针不可更改
- [ ] gestures.cpp:293 :304 这里可能有内存泄漏，需要先析构列表中的元素，或者使用智能指针 -> 已确认，列表的指针被另一个列表持有，这里不应析构
- [x] gestures.cpp:330 这里的if有些过于冗余，可以融合一下
- [x] gestures.cpp:353 显示添加fallthrough（使用标准库的）
- [x] gestures.cpp:366 这里不应该用unreachable，应该用break或者打印错误日志
- [x] helper.h:100 这里的flag应该是位域
- [x] helper.h:131 使用WAYLIB_SERVER_NAMESPACE
- [ ] helper.cpp:597 outputInfo应该在合适时机析构 -> 本次不修改，重构后修改
- [x] helper.cpp:6-8 这里应该使用target_include_directories去掉相对目录
- [x] helper.cpp:63-64 应该使用大写开头的头文件
- [x] helper.cpp:73 这里的logging category名字不规范，不应该包含debug
- [x] helper.cpp:75 应该使用static而不是inline
- [ ] helper.cpp:114 使用macro定义版本6 -> 上游都是这样用，暂不修改
- [ ] helper.cpp:133-149 在有多个xwayland的情况下，xwayland->waylandClient会崩溃，这是一个bug -> 重构后再修改
- [x] helper.cpp:161 这里应该使用qFatal
- [x] helper.cpp: 706 这里应该添加警告
- [x] helper.cpp:914-922 使用QRectF的adjust函数
- [x] inputdevice.cpp:19-20 这里不需要wlr的header
- [x] inputdevice.cpp 使用宏替代3作为最多手指数
