### PR TITLE
fix: better active control and fix some error assert

### DIFF
--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -99,7 +99,7 @@ void ForeignToplevelV1::addSurface(SurfaceWrapper *wrapper)
                 &treeland_foreign_toplevel_handle_v1::requestActivate,
                 this,
                 [wrapper, this](treeland_foreign_toplevel_handle_v1_activated_event *event) {
-                    Helper::instance()->activateSurface(wrapper);
+                    Q_EMIT wrapper->requestForceActive();
                 }));
 
     connection.push_back(

--- a/src/treeland/surfacewrapper.cpp
+++ b/src/treeland/surfacewrapper.cpp
@@ -145,14 +145,13 @@ void SurfaceWrapper::setParent(QQuickItem *item)
 
 void SurfaceWrapper::setActivate(bool activate)
 {
+    Q_ASSERT(!activate || hasActiveCapability());
     m_shellSurface->setActivate(activate);
     auto parent = parentSurface();
     while (parent) {
         parent->setActivate(activate);
         parent = parent->parentSurface();
     }
-    if (activate && isMinimized()) // activate surface shouldn't minimize
-        requestCancelMinimize();
 }
 
 void SurfaceWrapper::setFocus(bool focus, Qt::FocusReason reason)

--- a/src/treeland/surfacewrapper.h
+++ b/src/treeland/surfacewrapper.h
@@ -255,6 +255,7 @@ Q_SIGNALS:
     void showOnAllWorkspaceChanged();
     void requestActive();
     void requestDeactive();
+    void requestForceActive();
     void skipSwitcherChanged();
     void skipDockPreViewChanged();
     void skipMutiTaskViewChanged();

--- a/src/treeland/workspace.cpp
+++ b/src/treeland/workspace.cpp
@@ -271,6 +271,7 @@ void Workspace::pushActivedSurface(SurfaceWrapper *surface)
         m_showOnAllWorkspaceModel->pushActivedSurface(surface);
     } else {
         auto wpModle = model(surface->workspaceId());
+        Q_ASSERT(wpModle);
         wpModle->pushActivedSurface(surface);
     }
 }
@@ -283,6 +284,7 @@ void Workspace::removeActivedSurface(SurfaceWrapper *surface)
         m_showOnAllWorkspaceModel->removeActivedSurface(surface);
     } else {
         auto wpModle = model(surface->workspaceId());
+        Q_ASSERT(wpModle);
         wpModle->removeActivedSurface(surface);
     }
 }

--- a/src/treeland/workspacemodel.cpp
+++ b/src/treeland/workspacemodel.cpp
@@ -6,7 +6,7 @@
 #include "helper.h"
 #include "surfacewrapper.h"
 
-WorkspaceModel::WorkspaceModel(QObject *parent, int index, std::list<SurfaceWrapper *> activedSurfaceHistory)
+WorkspaceModel::WorkspaceModel(QObject *parent, int index, std::forward_list<SurfaceWrapper *> activedSurfaceHistory)
     : SurfaceListModel(parent)
     , m_index(index)
     , m_activedSurfaceHistory(activedSurfaceHistory)

--- a/src/treeland/workspacemodel.h
+++ b/src/treeland/workspacemodel.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "surfacecontainer.h"
+#include <forward_list>
+
 class SurfaceWrapper;
 class Workspace;
 
@@ -18,7 +20,7 @@ class WorkspaceModel : public SurfaceListModel
     QML_ELEMENT
 
 public:
-    explicit WorkspaceModel(QObject *parent, int index, std::list<SurfaceWrapper *> activedSurfaceHistory);
+    explicit WorkspaceModel(QObject *parent, int index, std::forward_list<SurfaceWrapper *> activedSurfaceHistory);
 
     QString name() const;
     void setName(const QString &newName);
@@ -45,5 +47,5 @@ private:
     QString m_name;
     int m_index = -1;
     bool m_visible = false;
-    std::list<SurfaceWrapper *> m_activedSurfaceHistory;
+    std::forward_list<SurfaceWrapper *> m_activedSurfaceHistory;
 };


### PR DESCRIPTION
1. 增加 requestForceActive 信号，和 requestActive 不同的是会自动取消最小化，并切换到 surface 所在工作区
2.  SurfaceWrapper::setActivate 不会取消最小化（最小化时禁止调用setActivate， 如有需要使用requestForceActive）
3.  不用为 popup 的 requestActive 等信号设置监听
4. Helper::activateSurface 断言太早（或者说没有考虑hasCapability）， 移动到 Helper::setActivatedSurface
5. 修复 WXdgSurface::parentXdgSurfaceChanged 时 container->addSurface 调用错误，（Workspace 的 addSurface 不是虚函数 ）

@zccrs  @Groveer 