### PR TITLE
fix: surface proxy accepts event

### DIFF
--- a/src/qml/Decoration.qml
+++ b/src/qml/Decoration.qml
@@ -11,6 +11,7 @@ Item {
 
     required property SurfaceWrapper surface
     readonly property SurfaceItem surfaceItem: surface.surfaceItem
+    readonly property bool rejectEvent: surfaceItem.flags & SurfaceItem.RejectEvent
 
     visible: surface && surface.visibleDecoration
     x: shadow.boundingRect.x
@@ -19,6 +20,7 @@ Item {
     height: shadow.boundingRect.height
 
     MouseArea {
+        enabled: !rejectEvent
         property int edges: 0
 
         anchors {


### PR DESCRIPTION
SurfaceProxy should not accept event. When SurfaceItem has the Flag RejectEvent, titlebar and decoration should also reject event.