### PR TITLE
refactor: code review

### DIFF
--- a/src/treeland/inputdevice.cpp
+++ b/src/treeland/inputdevice.cpp
@@ -3,9 +3,6 @@
 
 #include "inputdevice.h"
 
-#include "global.h"
-#include "togglablegesture.h"
-
 #include <winputdevice.h>
 
 #include <qwbackend.h>
@@ -19,7 +16,6 @@ QW_USE_NAMESPACE
 
 #define MIN_SWIPE_FINGERS 3
 
-Q_DECLARE_LOGGING_CATEGORY(inputdevice);
 Q_LOGGING_CATEGORY(inputdevice, "treeland.inputdevice", QtDebugMsg);
 
 static bool ensureStatus(libinput_config_status status)

--- a/src/treeland/inputdevice.h
+++ b/src/treeland/inputdevice.h
@@ -9,8 +9,6 @@
 
 #include <wglobal.h>
 
-#include <qwglobal.h>
-
 #include <QInputDevice>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE

--- a/src/treeland/lockscreen.cpp
+++ b/src/treeland/lockscreen.cpp
@@ -17,6 +17,7 @@ LockScreen::LockScreen(SurfaceContainer *parent)
     connect(m_delayTimer.get(), &QTimer::timeout, this, &LockScreen::unlock);
 
     m_delayTimer->setSingleShot(true);
+    // Display desktop animation after lock screen animation with a delay of 300ms
     m_delayTimer->setInterval(300);
 
     IS_ENABLED = CmdLine::ref().useLockScreen();
@@ -60,6 +61,7 @@ void LockScreen::onAnimationPlayed()
 void LockScreen::onAnimationPlayFinished()
 {
     auto *item = qobject_cast<QQuickItem *>(sender());
+    Q_ASSERT(item);
     item->setVisible(false);
 
     m_components.clear();

--- a/src/treeland/qmlengine.cpp
+++ b/src/treeland/qmlengine.cpp
@@ -50,8 +50,9 @@ QQuickItem *QmlEngine::createComponent(QQmlComponent &component,
     }
     auto item = qobject_cast<QQuickItem *>(obj);
     Q_ASSERT_X(item, __func__, component.errorString().toStdString().c_str());
-    if (!item)
+    if (!item) {
         qCFatal(qLcTreelandEngine) << "Can't create component:" << component.errorString();
+    }
     item->setParent(parent);
     item->setParentItem(parent);
     component.completeCreate();
@@ -77,9 +78,10 @@ QObject *QmlEngine::createWindowMenu(QObject *parent)
 {
     auto context = qmlContext(parent);
     auto obj = windowMenuComponent.beginCreate(context);
-    if (!obj)
+    if (!obj) {
         qCFatal(qLcTreelandEngine)
-            << "Can't create WindowMenu:" << dockPreviewComponent.errorString();
+            << "Can't create WindowMenu:" << windowMenuComponent.errorString();
+    }
     obj->setParent(parent);
     windowMenuComponent.completeCreate();
 

--- a/src/treeland/shellhandler.cpp
+++ b/src/treeland/shellhandler.cpp
@@ -216,7 +216,7 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
             m_workspace->current()->pushActivedSurface(wrapper);
     });
 
-    connect(wrapper, &SurfaceWrapper::requestDeactive, this, [this, wrapper]() {
+    connect(wrapper, &SurfaceWrapper::requestInactive, this, [this, wrapper]() {
         m_workspace->removeActivedSurface(wrapper);
         Helper::instance()->activateSurface(m_workspace->current()->latestActiveSurface());
     });
@@ -310,7 +310,7 @@ void ShellHandler::setupSurfaceWindowMenu(SurfaceWrapper *wrapper)
 
 void ShellHandler::handleDdeShellSurfaceAdded(WSurface *surface, SurfaceWrapper *wrapper)
 {
-    wrapper->setIsDdeShellSurface(true);
+    wrapper->setIsDDEShellSurface(true);
     auto ddeShellSurface = m_refDDEShellV1->ddeShellSurfaceFromWSurface(surface);
     Q_ASSERT(ddeShellSurface);
     auto updateLayer = [ddeShellSurface, wrapper] {

--- a/src/treeland/surfacewrapper.cpp
+++ b/src/treeland/surfacewrapper.cpp
@@ -74,9 +74,7 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     shellSurface->safeConnect(&WToplevelSurface::requestCancelMaximize,
                               this,
                               &SurfaceWrapper::requestCancelMaximize);
-    shellSurface->safeConnect(&WToplevelSurface::requestMove, this, [this](WSeat *, quint32) {
-        Q_EMIT requestMove();
-    });
+    shellSurface->safeConnect(&WToplevelSurface::requestMove, this, &SurfaceWrapper::requestMove);
     shellSurface->safeConnect(&WToplevelSurface::requestResize,
                               this,
                               [this](WSeat *, Qt::Edges edge, quint32) {
@@ -218,7 +216,7 @@ void SurfaceWrapper::moveNormalGeometryInOutput(const QPointF &position)
     if (isNormal()) {
         setPosition(position);
     } else if (m_pendingState == State::Normal && m_geometryAnimation) {
-        m_geometryAnimation->setProperty("targetGeometry", m_normalGeometry);
+        m_geometryAnimation->setProperty("toGeometry", m_normalGeometry);
     }
 }
 
@@ -779,6 +777,7 @@ void SurfaceWrapper::startShowAnimation(bool show)
 
 qreal SurfaceWrapper::radius() const
 {
+    // TODO: XdgToplevel、popup、InputPopup、XWayland(bypass、widnowtype(menu、normal、popup))
     if (m_radius < 1 && m_type != Type::Layer) {
         return TreelandConfig::ref().windowRadius();
     }
@@ -1128,7 +1127,8 @@ void SurfaceWrapper::setWorkspaceId(int newWorkspaceId)
     if (m_workspaceId == newWorkspaceId)
         return;
 
-    bool onAllWorkspaceHasChanged = m_workspaceId == 0 || newWorkspaceId == 0;
+    bool onAllWorkspaceHasChanged = m_workspaceId == Workspace::ShowOnAllWorkspaceId
+        || newWorkspaceId == Workspace::ShowOnAllWorkspaceId;
     m_workspaceId = newWorkspaceId;
 
     if (onAllWorkspaceHasChanged)
@@ -1226,7 +1226,7 @@ void SurfaceWrapper::updateHasActiveCapability(ActiveControlState state, bool va
         if (hasActiveCapability())
             Q_EMIT requestActive();
         else
-            Q_EMIT requestDeactive();
+            Q_EMIT requestInactive();
     }
 }
 
@@ -1277,18 +1277,18 @@ void SurfaceWrapper::setSkipMutiTaskView(bool skip)
     Q_EMIT skipMutiTaskViewChanged();
 }
 
-bool SurfaceWrapper::isDdeShellSurface() const
+bool SurfaceWrapper::isDDEShellSurface() const
 {
     return m_isDdeShellSurface;
 }
 
-void SurfaceWrapper::setIsDdeShellSurface(bool value)
+void SurfaceWrapper::setIsDDEShellSurface(bool value)
 {
     if (m_isDdeShellSurface == value)
         return;
 
     m_isDdeShellSurface = value;
-    Q_EMIT isDdeShellSurfaceChanged();
+    Q_EMIT isDDEShellSurfaceChanged();
 }
 
 SurfaceWrapper::SurfaceRole SurfaceWrapper::surfaceRole() const

--- a/src/treeland/surfacewrapper.h
+++ b/src/treeland/surfacewrapper.h
@@ -38,35 +38,35 @@ class SurfaceWrapper : public QQuickItem
     Q_PROPERTY(QRectF fullscreenGeometry READ fullscreenGeometry NOTIFY fullscreenGeometryChanged FINAL)
     Q_PROPERTY(QRectF tilingGeometry READ tilingGeometry NOTIFY tilingGeometryChanged FINAL)
     Q_PROPERTY(Output* ownsOutput READ ownsOutput NOTIFY ownsOutputChanged FINAL)
-    Q_PROPERTY(bool positionAutomatic READ positionAutomatic WRITE setPositionAutomatic NOTIFY positionAutomaticChanged FINAL)
+    Q_PROPERTY(bool positionAutomatic READ positionAutomatic NOTIFY positionAutomaticChanged FINAL)
     Q_PROPERTY(State previousSurfaceState READ previousSurfaceState NOTIFY previousSurfaceStateChanged FINAL)
     Q_PROPERTY(State surfaceState READ surfaceState NOTIFY surfaceStateChanged BINDABLE bindableSurfaceState FINAL)
-    Q_PROPERTY(qreal radius READ radius WRITE setRadius NOTIFY radiusChanged FINAL)
+    Q_PROPERTY(qreal radius READ radius NOTIFY radiusChanged FINAL)
     Q_PROPERTY(SurfaceContainer* container READ container NOTIFY containerChanged FINAL)
     Q_PROPERTY(QQuickItem* titleBar READ titleBar NOTIFY noTitleBarChanged FINAL)
     Q_PROPERTY(QQuickItem* decoration READ decoration NOTIFY noDecorationChanged FINAL)
     Q_PROPERTY(bool visibleDecoration READ visibleDecoration NOTIFY visibleDecorationChanged FINAL)
-    Q_PROPERTY(bool clipInOutput READ clipInOutput WRITE setClipInOutput NOTIFY clipInOutputChanged FINAL)
+    Q_PROPERTY(bool clipInOutput READ clipInOutput NOTIFY clipInOutputChanged FINAL)
     Q_PROPERTY(bool noTitleBar READ noTitleBar RESET resetNoTitleBar NOTIFY noTitleBarChanged FINAL)
     Q_PROPERTY(bool noCornerRadius READ noCornerRadius NOTIFY noCornerRadiusChanged FINAL)
     Q_PROPERTY(int workspaceId READ workspaceId NOTIFY workspaceIdChanged FINAL)
     Q_PROPERTY(bool alwaysOnTop READ alwaysOnTop WRITE setAlwaysOnTop NOTIFY alwaysOnTopChanged FINAL)
     Q_PROPERTY(bool showOnAllWorkspace READ showOnAllWorkspace NOTIFY showOnAllWorkspaceChanged FINAL)
-    Q_PROPERTY(bool skipSwitcher READ skipSwitcher WRITE setSkipSwitcher NOTIFY skipSwitcherChanged FINAL)
-    Q_PROPERTY(bool skipDockPreView READ skipDockPreView WRITE setSkipDockPreView NOTIFY skipDockPreViewChanged FINAL)
-    Q_PROPERTY(bool skipMutiTaskView READ skipMutiTaskView WRITE setSkipMutiTaskView NOTIFY skipMutiTaskViewChanged FINAL)
-    Q_PROPERTY(bool isDdeShellSurface READ isDdeShellSurface WRITE setIsDdeShellSurface NOTIFY isDdeShellSurfaceChanged FINAL)
-    Q_PROPERTY(SurfaceWrapper::SurfaceRole surfaceRole READ surfaceRole WRITE setSurfaceRole NOTIFY surfaceRoleChanged FINAL)
+    Q_PROPERTY(bool skipSwitcher READ skipSwitcher NOTIFY skipSwitcherChanged FINAL)
+    Q_PROPERTY(bool skipDockPreView READ skipDockPreView NOTIFY skipDockPreViewChanged FINAL)
+    Q_PROPERTY(bool skipMutiTaskView READ skipMutiTaskView NOTIFY skipMutiTaskViewChanged FINAL)
+    Q_PROPERTY(bool isDDEShellSurface READ isDDEShellSurface NOTIFY isDDEShellSurfaceChanged FINAL)
+    Q_PROPERTY(SurfaceWrapper::SurfaceRole surfaceRole READ surfaceRole NOTIFY surfaceRoleChanged FINAL)
     // y-axis offset distance, set the vertical alignment of the surface within
     // the cursor width. if autoPlaceYOffset > 0, preventing SurfaceWrapper from
     // being displayed beyond the edge of the output.
-    Q_PROPERTY(quint32 autoPlaceYOffset READ autoPlaceYOffset WRITE setAutoPlaceYOffset NOTIFY autoPlaceYOffsetChanged FINAL)
+    Q_PROPERTY(quint32 autoPlaceYOffset READ autoPlaceYOffset NOTIFY autoPlaceYOffsetChanged FINAL)
     // wayland client can control the position of SurfaceWrapper on the output
     // through treeland_dde_shell_surface_v1.set_surface_position
-    Q_PROPERTY(QPoint clientRequstPos READ clientRequstPos WRITE setClientRequstPos NOTIFY clientRequstPosChanged FINAL)
+    Q_PROPERTY(QPoint clientRequstPos READ clientRequstPos NOTIFY clientRequstPosChanged FINAL)
     Q_PROPERTY(bool blur READ blur NOTIFY blurChanged FINAL)
     Q_PROPERTY(bool isWindowAnimationRunning READ isWindowAnimationRunning NOTIFY windowAnimationRunningChanged FINAL)
-    Q_PROPERTY(bool coverEnabled READ coverEnabled WRITE setCoverEnabled NOTIFY coverEnabledChanged FINAL)
+    Q_PROPERTY(bool coverEnabled READ coverEnabled NOTIFY coverEnabledChanged FINAL)
 
 public:
     enum class Type
@@ -212,8 +212,8 @@ public:
     bool skipMutiTaskView() const;
     void setSkipMutiTaskView(bool skip);
 
-    bool isDdeShellSurface() const;
-    void setIsDdeShellSurface(bool value);
+    bool isDDEShellSurface() const;
+    void setIsDDEShellSurface(bool value);
 
     enum SurfaceRole surfaceRole() const;
     void setSurfaceRole(enum SurfaceRole role);
@@ -272,11 +272,11 @@ Q_SIGNALS:
     void alwaysOnTopChanged();
     void showOnAllWorkspaceChanged();
     void requestActive();
-    void requestDeactive();
+    void requestInactive();
     void skipSwitcherChanged();
     void skipDockPreViewChanged();
     void skipMutiTaskViewChanged();
-    void isDdeShellSurfaceChanged();
+    void isDDEShellSurfaceChanged();
     void surfaceRoleChanged();
     void autoPlaceYOffsetChanged();
     void clientRequstPosChanged();


### PR DESCRIPTION
- [x] gestures.cpp 251 注释代码需要对齐
- [x] inputdevice.h 12 : 确认是否需要
- [x] inputdevice.cpp 5： 删除#include "global.h"
- [x] inputdevice.cpp 21行：删除Q_DECLARE_LOGGING_CATEGORY(inputdevice);
- [ ] lockscreen.cpp 1:开源许可： 其他文件统一改成公司的 -> 开源许可在开源时统一处理
- [x] lockscreen.cpp 20： 添加300ms 注释说明
- [x] lockscreen.cpp 63： 添加item 断言
- [ ] qmlengine.h 33: 窗口相关的单独分模块处理 -> 由于复杂性，暂不处理
- [x] qmlengine.cpp 228： if 统一加{}
- [x] qmlengine.cpp item 断言判断统一改成：qCFatal(qLcTreelandEngine)
- [ ] surfaceproxy.cpp 115: size().isEmpty() 待确认 ->
  未出问题前维持现状
- [x] surfacewarpper.cpp 69: 修改为直接发送信号
- [x] surfacewarpper.cpp 207： targetGeometry 属性可能已经删除 待确认
- [ ] surfacewarpper.cpp 719： 检查Xdg、xwayland -> 添加todo,需要详细优化
- [x] surfacewarpper.cpp 1069：使用宏Workspace::ShowOnAllWorkspaceIndex替换0
- [x] surfacewarpper.cpp 1147：拼写修改
- [x] surfacewarpper.cpp 检查哪些属性需要readonly
- [x] surfacewarpper.cpp 1198： isDdeShellSurface 修改为 isDDEShellSurface 其他同样修改

Log: