### PR TITLE
fix: Crash when exiting treeland

### DIFF
--- a/src/treeland/layersurfacecontainer.cpp
+++ b/src/treeland/layersurfacecontainer.cpp
@@ -111,7 +111,9 @@ void LayerSurfaceContainer::addSurfaceToContainer(SurfaceWrapper *surface)
 {
     Q_ASSERT(!surface->container());
     auto shell = qobject_cast<WLayerSurface *>(surface->shellSurface());
-    auto output = shell->output() ? shell->output() : rootContainer()->primaryOutput()->output();
+    auto output = shell->output()          ? shell->output()
+        : rootContainer()->primaryOutput() ? rootContainer()->primaryOutput()->output()
+                                           : nullptr;
     if (!output) {
         qCWarning(qLcLayerShell) << "No output, will close layer surface!";
         shell->closed();

--- a/src/treeland/shellhandler.cpp
+++ b/src/treeland/shellhandler.cpp
@@ -224,8 +224,14 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
 
 void ShellHandler::onLayerSurfaceAdded(WLayerSurface *surface)
 {
+    if (!surface->output() && !m_rootSurfaceContainer->primaryOutput()) {
+        qWarning() << "No output, will close layer surface!";
+        surface->closed();
+        return;
+    }
     auto wrapper =
         new SurfaceWrapper(Helper::instance()->qmlEngine(), surface, SurfaceWrapper::Type::Layer);
+
     wrapper->setSkipSwitcher(true);
     wrapper->setSkipDockPreView(true);
     wrapper->setSkipMutiTaskView(true);
@@ -243,6 +249,10 @@ void ShellHandler::onLayerSurfaceAdded(WLayerSurface *surface)
 void ShellHandler::onLayerSurfaceRemoved(WLayerSurface *surface)
 {
     auto wrapper = m_rootSurfaceContainer->getSurface(surface->surface());
+    if (!wrapper) {
+        qWarning() << "A layerSurface that not in any Container is removing!";
+        return;
+    }
     Q_EMIT surfaceWrapperAboutToRemove(wrapper);
     m_rootSurfaceContainer->destroyForSurface(wrapper);
 }


### PR DESCRIPTION
layershell null pointer crash.

After layershell is destroyed, if the screen exists, dock will recreate layershell and cause a crash.