### PR TITLE
fix: Crash when dragging the workspace to swap the workspace position

### DIFF
--- a/src/treeland/workspace.cpp
+++ b/src/treeland/workspace.cpp
@@ -455,7 +455,9 @@ bool WorkspaceListModel::moveRows(const QModelIndex &sourceParent,
                       sourceRow,
                       {},
                       destinationChild > sourceRow ? (destinationChild + 1) : destinationChild);
+    if (!beginSuccess)
+        return false;
     m_objects.move(sourceRow, destinationChild);
     endMoveRows();
-    return beginSuccess;
+    return true;
 }


### PR DESCRIPTION
According to Qt official usage, beginMoveRows should return false when it fails, and endMoveRows should not be executed, otherwise an exception will occur.

https://doc.qt.io/qt-6/qabstractitemmodel.html#beginMoveRows
"This method returns false if either condition is true, in which case you should abort your move operation."