### PR TITLE
chore: rename BUILD_TEST_EXAMPLES to BUILD_EXAMPLES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ add_subdirectory(src)
 add_subdirectory(misc)
 add_subdirectory(tests)
 
-if (BUILD_TEST_EXAMPLES)
+if (BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 # package maintainers to append LDFLAGS
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
-TREELAND_CMAKE_ARGS = -DBUILD_TEST_EXAMPLES=ON
+TREELAND_CMAKE_ARGS = -DBUILD_EXAMPLES=ON
 
 %:
 	dh $@


### PR DESCRIPTION
remove test prefix

Log: