### PR TITLE
fix: crash when call remove x11 surface after dissociate

### DIFF
--- a/src/core/surfacewrapper.cpp
+++ b/src/core/surfacewrapper.cpp
@@ -229,7 +229,7 @@ void SurfaceWrapper::setFocus(bool focus, Qt::FocusReason reason)
 
 WSurface *SurfaceWrapper::surface() const
 {
-    return m_shellSurface->surface();
+    return m_shellSurface ? m_shellSurface->surface() : nullptr;
 }
 
 WToplevelSurface *SurfaceWrapper::shellSurface() const
@@ -581,8 +581,8 @@ void SurfaceWrapper::updateBoundingRect()
 
 void SurfaceWrapper::updateVisible()
 {
-    setVisible(!m_hideByWorkspace && !isMinimized() && surface()->mapped() && m_socketEnabled
-               && m_hideByshowDesk);
+    setVisible(!m_hideByWorkspace && !isMinimized() && (surface() && surface()->mapped())
+               && m_socketEnabled && m_hideByshowDesk);
 }
 
 void SurfaceWrapper::updateSubSurfaceStacking()


### PR DESCRIPTION
Log: when x11 notify_dissociate wl_surface maybe null

修复 bug 15： https://github.com/linuxdeepin/treeland/issues/358