### PR TITLE
refactor: change modules name

### DIFF
--- a/src/modules/capture/CMakeLists.txt
+++ b/src/modules/capture/CMakeLists.txt
@@ -8,6 +8,10 @@ pkg_search_module(WLROOTS REQUIRED IMPORTED_TARGET wlroots)
 
 qt_add_library(${MODULE_NAME} SHARED)
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-capture-v1"
+)
+
 target_sources(${MODULE_NAME} PUBLIC
     capture.h
     capture.cpp

--- a/src/modules/dde-shell/CMakeLists.txt
+++ b/src/modules/dde-shell/CMakeLists.txt
@@ -6,6 +6,10 @@ pkg_search_module(WLROOTS REQUIRED IMPORTED_TARGET wlroots)
 
 qt_add_library(${MODULE_NAME} SHARED)
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-dde-shell-v1"
+)
+
 local_qtwayland_server_protocol_treeland(${MODULE_NAME}
     PROTOCOL ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-dde-shell-v1.xml
     BASENAME treeland-dde-shell-v1

--- a/src/modules/foreign-toplevel/CMakeLists.txt
+++ b/src/modules/foreign-toplevel/CMakeLists.txt
@@ -8,6 +8,10 @@ pkg_search_module(WLROOTS REQUIRED IMPORTED_TARGET wlroots)
 
 qt_add_library(${MODULE_NAME} SHARED)
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-foreign-toplevel-v1"
+)
+
 target_sources(${MODULE_NAME} PUBLIC
 FILE_SET HEADERS
 FILES

--- a/src/modules/item-selector/CMakeLists.txt
+++ b/src/modules/item-selector/CMakeLists.txt
@@ -5,6 +5,10 @@ qt_add_library(${MODULE_NAME} SHARED
     itemselector.cpp
 )
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-item-selector-v1"
+)
+
 target_include_directories(${MODULE_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/src/modules/personalization/CMakeLists.txt
+++ b/src/modules/personalization/CMakeLists.txt
@@ -9,6 +9,10 @@ find_package(Dtk6Core REQUIRED)
 
 qt_add_library(${MODULE_NAME} SHARED)
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-personalization-v1"
+)
+
 qt_add_resources(${MODULE_NAME} "default_background"
     PREFIX "/"
     FILES

--- a/src/modules/primary-output/CMakeLists.txt
+++ b/src/modules/primary-output/CMakeLists.txt
@@ -8,6 +8,10 @@ pkg_search_module(WLROOTS REQUIRED IMPORTED_TARGET wlroots)
 
 qt_add_library(${MODULE_NAME} SHARED)
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-output-management-v1"
+)
+
 target_sources(${MODULE_NAME} PUBLIC
 FILE_SET HEADERS
 FILES

--- a/src/modules/shortcut/CMakeLists.txt
+++ b/src/modules/shortcut/CMakeLists.txt
@@ -8,6 +8,10 @@ pkg_search_module(WLROOTS REQUIRED IMPORTED_TARGET wlroots)
 
 qt_add_library(${MODULE_NAME} SHARED)
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-shortcut-v1"
+)
+
 target_sources(${MODULE_NAME} PUBLIC
 FILE_SET HEADERS
 FILES

--- a/src/modules/virtual-output/CMakeLists.txt
+++ b/src/modules/virtual-output/CMakeLists.txt
@@ -8,6 +8,10 @@ pkg_search_module(WLROOTS REQUIRED IMPORTED_TARGET wlroots)
 
 qt_add_library(${MODULE_NAME} SHARED)
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-virtual-output-v1"
+)
+
 target_sources(${MODULE_NAME} PUBLIC
 FILE_SET HEADERS
 FILES

--- a/src/modules/wallpaper-color/CMakeLists.txt
+++ b/src/modules/wallpaper-color/CMakeLists.txt
@@ -8,6 +8,10 @@ pkg_search_module(WLROOTS REQUIRED IMPORTED_TARGET wlroots)
 
 qt_add_library(${MODULE_NAME} SHARED)
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-wallpaper-color-v1"
+)
+
 target_sources(${MODULE_NAME} PUBLIC
 FILE_SET HEADERS
 FILES

--- a/src/modules/window-management/CMakeLists.txt
+++ b/src/modules/window-management/CMakeLists.txt
@@ -8,6 +8,10 @@ pkg_search_module(WLROOTS REQUIRED IMPORTED_TARGET wlroots)
 
 qt_add_library(${MODULE_NAME} SHARED)
 
+set_target_properties(${MODULE_NAME} PROPERTIES
+    OUTPUT_NAME "treeland-protocol-window-management-v1"
+)
+
 target_sources(${MODULE_NAME} PUBLIC
 FILE_SET HEADERS
 FILES


### PR DESCRIPTION
Some protocols, such as dde-shell, have the same name as the project.

Log: