### PR TITLE
fix: layershell not shown on init

### DIFF
--- a/src/core/output.cpp
+++ b/src/core/output.cpp
@@ -20,6 +20,7 @@
 #include <wxdgpopupsurface.h>
 
 #include <qwoutputlayout.h>
+#include <qwlayershellv1.h>
 
 #include <QQmlEngine>
 
@@ -402,6 +403,9 @@ void Output::arrangeLayerSurface(SurfaceWrapper *surface)
 {
     WLayerSurface *layer = qobject_cast<WLayerSurface *>(surface->shellSurface());
     Q_ASSERT(layer);
+    if (!layer->handle()->handle()->initialized) {
+        return;
+    }
 
     auto validGeo = layer->exclusiveZone() == -1 ? geometry() : validGeometry();
     validGeo = validGeo.marginsRemoved(QMargins(layer->leftMargin(),


### PR DESCRIPTION
The internal information of an uninitialized shell surface may not be correct. If configure it at this time, the client will receive an error message. For example, if the layershell surface has no anchor information, its size will be incorrect.

pms: BUG-288905