### PR TITLE
fix: crash when resize or remove output while a SurfaceWrapper destory

### DIFF
--- a/src/core/helper.h
+++ b/src/core/helper.h
@@ -101,7 +101,7 @@ class Helper : public WSeatEventFilter
 
 public:
     explicit Helper(QObject *parent = nullptr);
-    ~Helper();
+    ~Helper() override;
 
     enum class OutputMode
     {

--- a/src/core/output.h
+++ b/src/core/output.h
@@ -57,7 +57,7 @@ public:
                               QObject *parent = nullptr);
 
     explicit Output(WOutputItem *output, QObject *parent = nullptr);
-    ~Output();
+    ~Output() override;
 
     bool isPrimary() const;
 

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -100,7 +100,6 @@ void RootSurfaceContainer::destroyForSurface(SurfaceWrapper *wrapper)
     if (wrapper == moveResizeState.surface)
         endMoveResize();
 
-    wrapper->container()->removeSurface(wrapper);
     wrapper->markWrapperToRemoved();
 }
 

--- a/src/core/surfacewrapper.h
+++ b/src/core/surfacewrapper.h
@@ -111,7 +111,6 @@ public:
                             Type type,
                             QQuickItem *parent = nullptr,
                             bool isProxy = false);
-    ~SurfaceWrapper() override;
 
     void setFocus(bool focus, Qt::FocusReason reason);
 
@@ -299,6 +298,7 @@ Q_SIGNALS:
     void aboutToBeInvalidated();
 
 private:
+    ~SurfaceWrapper() override;
     using QQuickItem::setParentItem;
     using QQuickItem::stackAfter;
     using QQuickItem::stackBefore;


### PR DESCRIPTION
close: https://github.com/linuxdeepin/treeland.private/issues/487