### PR TITLE
fix: Window displays problem when switching workspace

### DIFF
--- a/src/core/helper.h
+++ b/src/core/helper.h
@@ -260,6 +260,7 @@ private:
                               Output *sourceOutput);
     bool isNvidiaCardPresent();
     void setWorkspaceVisible(bool visible);
+    void restoreFromShowDesktop(SurfaceWrapper *activeSurface = nullptr);
 
     static Helper *m_instance;
 


### PR DESCRIPTION
After setting the show desktop, switching the workspace should exit the show desktop mode and restore the real state of the window.