### PR TITLE
fix: animation clipped

### DIFF
--- a/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
+++ b/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
@@ -95,7 +95,7 @@ Item {
             }
         ]
         state: {
-            if (exited)
+            if (exited || status === Multitaskview.Uninitialized)
                 return "initial";
 
             if (multitaskview.activeReason === Multitaskview.ShortcutKey){


### PR DESCRIPTION
Multitaskview should be in initial state when created. Otherwise it do not receive a state change when first to taskview.