### PR TITLE
fix: nullptr wrap data

### DIFF
--- a/src/core/wrappointer.h
+++ b/src/core/wrappointer.h
@@ -20,6 +20,7 @@ struct WrapData
     WrapData(T *p)
         : ptr(p)
     {
+        Q_ASSERT_X(p, __func__, "WrapData is only for non-null ptr.");
         conn = QObject::connect(p,
                                 &T::aboutToBeInvalidated,
                                 p,
@@ -33,6 +34,12 @@ struct WrapData
         ptr = nullptr;
         Q_ASSERT_X(conn, __func__, "Connection should be valid until invalidated.");
         QObject::disconnect(conn);
+    }
+
+    ~WrapData()
+    {
+        if (ptr)
+            invalidate();
     }
 };
 
@@ -76,7 +83,7 @@ public:
 
     WrapPointer<T> &operator=(T *p)
     {
-        wd.reset(new WrapData<T>(p));
+        wd.reset(p ? new WrapData<T>(p) : nullptr);
         return *this;
     }
 

--- a/tests/test_wrappointer/main.cpp
+++ b/tests/test_wrappointer/main.cpp
@@ -127,6 +127,17 @@ private Q_SLOTS:
         }
     }
 
+    void testNullAssignment()
+    {
+        FakeWrapObject *p = new FakeWrapObject;
+        QScopedPointer<FakeWrapObject> sp(p);
+        QPointer<FakeWrapObject> qp(p);
+        WrapPointer<FakeWrapObject> wp(p);
+        TEST_ACCESS(wp, p);
+        wp = nullptr;
+        QVERIFY(!wp);
+    }
+
     void cleanupTestCase() { }
 };
 

--- a/tests/test_wrappointer/wrapobject.h
+++ b/tests/test_wrappointer/wrapobject.h
@@ -32,6 +32,11 @@ public:
     {
     }
 
+    ~FakeWrapObject() override
+    {
+        invalidate();
+    }
+
     void invalidate()
     {
         delete m_object;


### PR DESCRIPTION
WrapData is only constructed for non-null ptr. By the way, connection
is not connected to the life scope of wrapdata. Invalidate WrapData
on destructed.