### PR TITLE
fix: wallpaper not scaled

### DIFF
--- a/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
+++ b/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
@@ -159,6 +159,7 @@ Item {
                         ShapePath {
                             strokeWidth: 0
                             fillItem: wallpaper
+                            fillTransform: PlanarTransform.fromScale(content.width / wpCtrl.proxy.width, content.height / wpCtrl.proxy.height, 0, 0)
                             PathRectangle {
                                 width: content.width
                                 height: content.height


### PR DESCRIPTION
ShapePath fillItem will use original textureProvider that is not scaled by ShaderEffectSource. Do the scale transform on fillTransform.