### PR TITLE
fix: notitlebar window not show border

### DIFF
--- a/src/modules/personalization/personalizationmanager.cpp
+++ b/src/modules/personalization/personalizationmanager.cpp
@@ -9,6 +9,7 @@
 #include "treelandconfig.h"
 
 #include <wlayersurface.h>
+#include <wxdgpopupsurface.h>
 #include <wxdgshell.h>
 #include <wxdgsurface.h>
 
@@ -510,6 +511,19 @@ PersonalizationAttached::PersonalizationAttached(WToplevelSurface *target,
 Personalization::BackgroundType PersonalizationAttached::backgroundType() const
 {
     return static_cast<Personalization::BackgroundType>(m_backgroundType);
+}
+
+bool PersonalizationAttached::noTitlebar() const
+{
+    if (qobject_cast<WAYLIB_SERVER_NAMESPACE::WXdgPopupSurface *>(m_target)) {
+        return true;
+    }
+
+    if (qobject_cast<WAYLIB_SERVER_NAMESPACE::WLayerSurface *>(m_target)) {
+        return true;
+    }
+
+    return m_states.testFlag(personalization_window_context_v1::NoTitleBar);
 }
 
 void PersonalizationV1::create(WServer *server)

--- a/src/modules/personalization/personalizationmanager.h
+++ b/src/modules/personalization/personalizationmanager.h
@@ -74,10 +74,7 @@ public:
         return m_border;
     }
 
-    bool noTitlebar() const
-    {
-        return m_states.testFlag(personalization_window_context_v1::NoTitleBar);
-    }
+    bool noTitlebar() const;
 
 Q_SIGNALS:
     void backgroundTypeChanged();


### PR DESCRIPTION
notitlebar window is a special type that expects to use the shadows, borders and rounded corners provided by the compositor, but does not want the SSD titlebar.

before: xdg window not border; popup window(launchpad) force border; layer window(dock) not border

<img width="1920" alt="截屏2024-12-05 11 30 00" src="https://github.com/user-attachments/assets/2e72472f-998b-407c-b251-e5d76947155e">

after: xdg/popup/layer have border, csd window not effect.

<img width="1920" alt="截屏2024-12-05 11 33 17" src="https://github.com/user-attachments/assets/df489016-9625-4201-9ae4-afa70c637946">
