### PR TITLE
fix treeland crash

### DIFF
--- a/src/core/workspacemodel.cpp
+++ b/src/core/workspacemodel.cpp
@@ -69,7 +69,7 @@ void WorkspaceModel::addSurface(SurfaceWrapper *surface)
     if (!m_opaque) {
         surface->setOpacity(m_opaque ? 1.0 : 0.0);
         surface->setHideByWorkspace(m_visible);
-        connect(this, &WorkspaceModel::opaqueChanged, this, [this, surface](){
+        connect(this, &WorkspaceModel::opaqueChanged, surface, [this, surface](){
             surface->setHideByWorkspace(!m_visible);
         });
     } else {
@@ -81,6 +81,7 @@ void WorkspaceModel::addSurface(SurfaceWrapper *surface)
 
 void WorkspaceModel::removeSurface(SurfaceWrapper *surface)
 {
+    surface->disconnect(this);
     SurfaceListModel::removeSurface(surface);
     surface->setWorkspaceId(-1);
     surface->setHideByWorkspace(false);


### PR DESCRIPTION
add disconnec on removeSurface


bt:
```shell
#0 0x7fde79623f5b in SurfaceWrapper::setHideByWorkspace(bool) src/core/surfacewrapper.cpp:1414
#1 0x7fde796c9cd9 in operator() src/core/workspacemodel.cpp:73
#2 0x7fde796c9cd9 in operator() /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:141
#3 0x7fde796c9cd9 in call_internal<void, QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, WorkspaceModel::addSurface(SurfaceWrapper*)::<lambda()> >::call(WorkspaceModel::addSurface(SurfaceWrapper*)::<lambda()>&, void**)::<lambda()> > /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:65
#4 0x7fde796c9cd9 in call /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:140
#5 0x7fde796c9cd9 in call<QtPrivate::List<>, void> /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:362
#6 0x7fde796c9cd9 in impl /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:572
#7 0x7fde781a596b  (/usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6+0x1a596b)
#8 0x7fde7952d78a in WorkspaceModel::opaqueChanged() obj-x86_64-linux-gnu/src/core/treeland_core_autogen/EWIEGA46WW/moc_workspacemodel.cpp:274
#9 0x7fde796cb1f2 in WorkspaceModel::setOpaque(bool) src/core/workspacemodel.cpp:63
.......
```