### PR TITLE
fix: capture mask regarded deleted in qml

### DIFF
--- a/src/modules/capture/capture.h
+++ b/src/modules/capture/capture.h
@@ -425,6 +425,7 @@ private:
     void handleItemSelectorSelectionRegionChanged();
     WOutputRenderWindow *renderWindow() const;
     void createImage();
+    void releaseMaskSurface();
 
     void updateItemSelectorItemTypes();
     void updateCursorShape();


### PR DESCRIPTION
Should reparent capture mask surface wrapper before destructor. Its QQmlData is marked as isQueuedForDeletion before destructor of CaptureSourceSelector is invoked.