### PR TITLE
chore: move treeland to system service

### DIFF
--- a/debian/treeland.install
+++ b/debian/treeland.install
@@ -1,5 +1,6 @@
 usr/bin/treeland
 usr/lib/systemd/user/*
+usr/lib/systemd/system/*
 usr/libexec/*
 usr/share/*/translations/*
 usr/share/dbus-1/system.d/*

--- a/misc/interfaces/org.deepin.DisplayManager.xml
+++ b/misc/interfaces/org.deepin.DisplayManager.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+    <interface name="org.deepin.DisplayManager">
+        <method name="AuthInfo">
+            <arg type="s" name="auth socket" direction="out">
+            </arg>
+        </method>
+        <signal name="AuthInfoChanged">
+        </signal>
+        <method name="LastActivatedUser">
+            <arg type="s" name="last activated user" direction="out">
+            </arg>
+        </method>
+        <signal name="LastActivatedUserChanged">
+        </signal>
+    </interface>
+</node>
+

--- a/misc/interfaces/org.freedesktop.login1.Manager.xml
+++ b/misc/interfaces/org.freedesktop.login1.Manager.xml
@@ -1,0 +1,220 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.login1.Manager">
+  <property name="NAutoVTs" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillOnlyUsers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillExcludeUsers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillUserProcesses" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <property name="BlockInhibited" type="s" access="read">
+  </property>
+  <property name="DelayInhibited" type="s" access="read">
+  </property>
+  <property name="InhibitDelayMaxUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandlePowerKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleSuspendKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleHibernateKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitch" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleAction" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleActionUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="PreparingForShutdown" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="PreparingForSleep" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <method name="GetSession">
+   <arg type="s" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="GetSessionByPID">
+   <arg type="u" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="GetUser">
+   <arg type="u" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="GetUserByPID">
+   <arg type="u" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="GetSeat">
+   <arg type="s" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="ListSessions">
+   <arg type="a(susso)" direction="out"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="SessionInfoList"/>
+  </method>
+  <method name="ListUsers">
+   <arg type="a(uso)" direction="out"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="UserInfoList"/>
+  </method>
+  <method name="ListSeats">
+   <arg type="a(so)" direction="out"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="NamedSeatPathList"/>
+  </method>
+  <method name="ListInhibitors">
+   <arg type="a(ssssuu)" direction="out"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="InhibitorList"/>
+  </method>
+  <method name="ReleaseSession">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="ActivateSession">
+   <arg type="s" direction="in"/>
+  </method>
+  <method name="ActivateSessionOnSeat">
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+  </method>
+  <method name="LockSession">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="UnlockSession">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="LockSessions">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="UnlockSessions">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="KillSession">
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="i" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="KillUser">
+   <arg type="u" direction="in"/>
+   <arg type="i" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="TerminateSession">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="TerminateUser">
+   <arg type="u" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="TerminateSeat">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="SetUserLinger">
+   <arg type="u" direction="in"/>
+   <arg type="b" direction="in"/>
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="AttachDevice">
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="FlushDevices">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="PowerOff">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="Reboot">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="Suspend">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="Hibernate">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="HybridSleep">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="CanPowerOff">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="CanReboot">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="CanSuspend">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="CanHibernate">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="CanHybridSleep">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="Inhibit">
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="h" direction="out"/>
+  </method>
+  <signal name="SessionNew">
+   <arg type="s"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="SessionRemoved">
+   <arg type="s"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="UserNew">
+   <arg type="u"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="UserRemoved">
+   <arg type="u"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="SeatNew">
+   <arg type="s"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="SeatRemoved">
+   <arg type="s"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="PrepareForShutdown">
+   <arg type="b"/>
+  </signal>
+  <signal name="PrepareForSleep">
+   <arg type="b"/>
+  </signal>
+ </interface>
+</node>
+

--- a/misc/interfaces/org.freedesktop.login1.Seat.xml
+++ b/misc/interfaces/org.freedesktop.login1.Seat.xml
@@ -1,0 +1,43 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.freedesktop.login1.Seat">
+  <property name="Id" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="ActiveSession" type="(so)" access="read">
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="NamedSessionPath"/>
+  </property>
+  <property name="CanMultiSession" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CanTTY" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CanGraphical" type="b" access="read">
+  </property>
+  <property name="Sessions" type="a(so)" access="read">
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;NamedSessionPath&gt;"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <method name="Terminate">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="ActivateSession">
+   <arg type="s" direction="in"/>
+  </method>
+  <method name="SwitchTo">
+   <arg type="u" direction="in"/>
+  </method>
+  <method name="SwitchToNext">
+  </method>
+  <method name="SwitchToPrevious">
+  </method>
+ </interface>
+</node>
+

--- a/misc/interfaces/org.freedesktop.login1.Session.xml
+++ b/misc/interfaces/org.freedesktop.login1.Session.xml
@@ -1,0 +1,132 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.login1.Session">
+  <property name="Id" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="User" type="(uo)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="NamedUserPath"/>
+  </property>
+  <property name="Name" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Timestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="TimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="VTNr" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Seat" type="(so)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="NamedSeatPath"/>
+  </property>
+  <property name="TTY" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Display" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Remote" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RemoteHost" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RemoteUser" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Service" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Desktop" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Scope" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Leader" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Audit" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Type" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Class" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+   <annotation name="org.qtproject.QtDBus.PropertyGetter" value="className"/>
+  </property>
+  <property name="Active" type="b" access="read">
+  </property>
+  <property name="State" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <method name="Terminate">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="Activate">
+  </method>
+  <method name="Lock">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+    <annotation name="org.qtproject.QtDBus.MethodName" value="requestLock"/>
+  </method>
+  <method name="Unlock">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+   <annotation name="org.qtproject.QtDBus.MethodName" value="requestUnlock"/>
+  </method>
+  <method name="SetIdleHint">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="Kill">
+   <arg type="s" direction="in"/>
+   <arg type="i" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="TakeControl">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="ReleaseControl">
+  </method>
+  <method name="TakeDevice">
+   <arg type="u" direction="in"/>
+   <arg type="u" direction="in"/>
+   <arg type="h" direction="out"/>
+   <arg type="b" direction="out"/>
+  </method>
+  <method name="ReleaseDevice">
+   <arg type="u" direction="in"/>
+   <arg type="u" direction="in"/>
+  </method>
+  <method name="PauseDeviceComplete">
+   <arg type="u" direction="in"/>
+   <arg type="u" direction="in"/>
+  </method>
+  <signal name="PauseDevice">
+   <arg type="u"/>
+   <arg type="u"/>
+   <arg type="s"/>
+  </signal>
+  <signal name="ResumeDevice">
+   <arg type="u"/>
+   <arg type="u"/>
+   <arg type="h"/>
+  </signal>
+  <signal name="Lock">
+  </signal>
+  <signal name="Unlock">
+  </signal>
+ </interface>
+</node>
+

--- a/misc/interfaces/org.freedesktop.login1.User.xml
+++ b/misc/interfaces/org.freedesktop.login1.User.xml
@@ -1,0 +1,56 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.login1.User">
+  <property name="UID" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="GID" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Name" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Timestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="TimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RuntimePath" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Service" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Slice" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Display" type="(so)" access="read">
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="NamedSessionPath"/>
+  </property>
+  <property name="State" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="Sessions" type="a(so)" access="read">
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;NamedSessionPath&gt;"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <property name="Linger" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <method name="Terminate">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="Kill">
+   <arg type="i" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+ </interface>
+</node>
+

--- a/misc/systemd/CMakeLists.txt
+++ b/misc/systemd/CMakeLists.txt
@@ -1,3 +1,9 @@
+if (NOT DEFINED SYSTEMD_SYSTEM_UNIT_DIR)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(Systemd REQUIRED systemd)
+    pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir)
+endif()
+
 if (NOT DEFINED SYSTEMD_USER_UNIT_DIR)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(Systemd REQUIRED systemd)
@@ -14,8 +20,10 @@ configure_file("dde-session-pre.target.wants/treeland-sd.service.in" "dde-sessio
 configure_file("dde-session-pre.target.wants/treeland-xwayland.service.in" "dde-session-pre.target.wants/treeland-xwayland.service" IMMEDIATE @ONLY)
 configure_file("dde-session-pre.target.wants/treeland-shortcut.service.in" "dde-session-pre.target.wants/treeland-shortcut.service" IMMEDIATE @ONLY)
 configure_file("dde-session-pre.target.wants/treeland.service.in" "dde-session-pre.target.wants/treeland.service" IMMEDIATE @ONLY)
+configure_file("treeland.service.in" "treeland.service" IMMEDIATE @ONLY)
 
 install(FILES ${SERVICES} DESTINATION ${SYSTEMD_USER_UNIT_DIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/treeland.service DESTINATION ${SYSTEMD_SYSTEM_UNIT_DIR})
 
 install(DIRECTORY DESTINATION ${SYSTEMD_USER_UNIT_DIR}/dde-session-pre.target.wants/)
 install(DIRECTORY DESTINATION ${SYSTEMD_USER_UNIT_DIR}/dde-session-shutdown.target.wants/)

--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -1,0 +1,16 @@
+[Unit]
+Description=Treeland global wayland compositor service, only running on DDM.
+PartOf=graphical.target
+StartLimitIntervalSec=30
+StartLimitBurst=2
+
+Requires=seatd.service
+After=seatd.service
+
+[Service]
+User=dde
+Environment=LIBSEAT_BACKEND=seatd
+Environment=DSG_APP_ID=org.deepin.dde.treeland
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland --lockscreen
+Restart=on-failure
+RestartSec=1s

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,9 +37,29 @@ set_source_files_properties("${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop
     CLASSNAME DisplaySession
 )
 
+set_source_files_properties("${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.login1.Manager.xml" PROPERTIES
+   INCLUDE "loginddbustypes.h"
+)
+set_source_files_properties("${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.login1.Seat.xml" PROPERTIES
+   INCLUDE "loginddbustypes.h"
+)
+
+set_source_files_properties("${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.login1.Session.xml" PROPERTIES
+   INCLUDE "loginddbustypes.h"
+)
+
+set_source_files_properties("${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.login1.User.xml" PROPERTIES
+   INCLUDE "loginddbustypes.h"
+)
+
 qt_add_dbus_interface(DDM_DBUS_SOURCES "${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.DisplayManager.xml"          DisplayManager)
 qt_add_dbus_interface(DDM_DBUS_SOURCES "${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.DisplayManager.Seat.xml"     DisplayManagerSeat)
 qt_add_dbus_interface(DDM_DBUS_SOURCES "${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.DisplayManager.Session.xml"  DisplayManagerSession)
+qt_add_dbus_interface(DDM_DBUS_SOURCES "${CMAKE_SOURCE_DIR}/misc/interfaces/org.deepin.DisplayManager.xml"               DDMDisplayManager)
+qt_add_dbus_interface(DBUS_INTERFACE   "${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.login1.Manager.xml"          Login1Manager)
+qt_add_dbus_interface(DBUS_INTERFACE   "${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.login1.Seat.xml"             Login1Seat)
+qt_add_dbus_interface(DBUS_INTERFACE   "${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.login1.Session.xml"          Login1Session)
+qt_add_dbus_interface(DBUS_INTERFACE   "${CMAKE_SOURCE_DIR}/misc/interfaces/org.freedesktop.login1.User.xml"             Login1User)
 
 qt_add_library(libtreeland SHARED)
 
@@ -54,6 +74,7 @@ qt_add_qml_module(libtreeland
     SOURCES
         ${DBUS_ADAPTOR}
         ${DDM_DBUS_SOURCES}
+        ${DBUS_INTERFACE}
         config/treelandconfig.cpp
         config/treelandconfig.h
         core/layersurfacecontainer.cpp
@@ -112,6 +133,8 @@ qt_add_qml_module(libtreeland
         utils/cmdline.h
         utils/propertymonitor.cpp
         utils/propertymonitor.h
+        utils/loginddbustypes.h
+        utils/loginddbustypes.cpp
         wallpaper/wallpapercontroller.cpp
         wallpaper/wallpapercontroller.h
         wallpaper/wallpaperimage.cpp

--- a/src/core/treeland.h
+++ b/src/core/treeland.h
@@ -35,8 +35,6 @@ public:
     explicit Treeland();
     ~Treeland();
 
-    bool testMode() const;
-
     bool debugMode() const;
 
     QmlEngine *qmlEngine() const override;

--- a/src/greeter/greeterproxy.h
+++ b/src/greeter/greeterproxy.h
@@ -106,6 +106,7 @@ Q_SIGNALS:
 private:
     bool localValidation(const QString &user, const QString &password) const;
     QString currentSessionPath() const;
+    void updateAuthSocket();
 
 private:
     GreeterProxyPrivate *d{ nullptr };

--- a/src/greeter/user.cpp
+++ b/src/greeter/user.cpp
@@ -24,6 +24,7 @@ struct UserPrivate
     QString passwordHint;
     QString limitTime;
     AccountsUserPtr inter{ nullptr };
+    std::shared_ptr<WAYLIB_SERVER_NAMESPACE::WSocket> waylandSocket;
 
     void updateUserData();
 };
@@ -128,6 +129,16 @@ void User::updateLimitTime(const QString &time) noexcept
 {
     d->limitTime = time;
     Q_EMIT limitTimeChanged(time);
+}
+
+void User::setWaylandSocket(std::shared_ptr<WAYLIB_SERVER_NAMESPACE::WSocket> socket)
+{
+    d->waylandSocket = socket;
+}
+
+std::shared_ptr<WAYLIB_SERVER_NAMESPACE::WSocket> User::waylandSocket() const
+{
+    return d->waylandSocket;
 }
 
 QString User::toString(AccountTypes type) noexcept

--- a/src/greeter/user.h
+++ b/src/greeter/user.h
@@ -5,6 +5,8 @@
 #ifndef USER_H
 #define USER_H
 
+#include <wsocket.h>
+
 #include <DAccountsManager>
 #include <DAccountsTypes>
 #include <DAccountsUser>
@@ -34,6 +36,9 @@ public:
     [[nodiscard]] static QString toString(AccountTypes type) noexcept;
     void setLogined(bool newState) const noexcept;
     void updateLimitTime(const QString &time) noexcept;
+
+    void setWaylandSocket(std::shared_ptr<WAYLIB_SERVER_NAMESPACE::WSocket>);
+    std::shared_ptr<WAYLIB_SERVER_NAMESPACE::WSocket> waylandSocket() const;
 
 Q_SIGNALS:
     void userDataChanged();

--- a/src/greeter/usermodel.cpp
+++ b/src/greeter/usermodel.cpp
@@ -315,6 +315,13 @@ void UserModel::updateUserLimits(const QString &userName, const QString &time) c
 void UserModel::setCurrentUserName(const QString &userName) noexcept
 {
     d->currentUserName = userName;
+
+    for (const auto &user : d->users) {
+        if (user->waylandSocket()) {
+            user->waylandSocket()->setEnabled(user->userName() == userName);
+        }
+    }
+
     Q_EMIT currentUserNameChanged();
 }
 

--- a/src/utils/cmdline.cpp
+++ b/src/utils/cmdline.cpp
@@ -16,15 +16,12 @@ Q_LOGGING_CATEGORY(qLcCmdline, "treeland.cmdline");
 CmdLine::CmdLine()
     : QObject()
     , m_parser(std::make_unique<QCommandLineParser>())
-    , m_socket(std::make_unique<QCommandLineOption>(QStringList{ "s", "socket" },
-                                                    "set ddm socket",
-                                                    "socket"))
     , m_run(std::make_unique<QCommandLineOption>(QStringList{ "r", "run" }, "run a process", "run"))
     , m_lockScreen(std::make_unique<QCommandLineOption>("lockscreen",
                                                         "use lockscreen, need DDM auth socket"))
 {
     m_parser->addHelpOption();
-    m_parser->addOptions({ *m_socket.get(), *m_run.get(), *m_lockScreen.get() });
+    m_parser->addOptions({ *m_run.get(), *m_lockScreen.get() });
     m_parser->process(*QCoreApplication::instance());
 }
 
@@ -121,15 +118,6 @@ std::optional<QStringList> CmdLine::unescapeExecArgs(const QString &str) noexcep
     }
 
     return execList;
-}
-
-std::optional<QString> CmdLine::socket() const
-{
-    if (m_parser->isSet(*m_socket.get())) {
-        return m_parser->value(*m_socket.get());
-    }
-
-    return std::nullopt;
 }
 
 std::optional<QString> CmdLine::run() const

--- a/src/utils/cmdline.h
+++ b/src/utils/cmdline.h
@@ -22,7 +22,6 @@ class CmdLine
     friend class DSingleton<CmdLine>;
 
 public:
-    std::optional<QString> socket() const;
     std::optional<QString> run() const;
     bool useLockScreen() const;
     std::optional<QStringList> unescapeExecArgs(const QString &str) noexcept;
@@ -34,7 +33,6 @@ private:
 
 private:
     std::unique_ptr<QCommandLineParser> m_parser;
-    std::unique_ptr<QCommandLineOption> m_socket;
     std::unique_ptr<QCommandLineOption> m_run;
     std::unique_ptr<QCommandLineOption> m_lockScreen;
 };

--- a/src/utils/loginddbustypes.cpp
+++ b/src/utils/loginddbustypes.cpp
@@ -1,0 +1,112 @@
+#include "loginddbustypes.h"
+
+#include <QDBusArgument>
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+#include <QDBusMetaType>
+#include <QDebug>
+
+class LogindPathInternal
+{
+public:
+    LogindPathInternal();
+    bool available = false;
+    QString serviceName;
+    QString managerPath;
+    QString managerIfaceName;
+    QString sessionIfaceName;
+    QString seatIfaceName;
+    QString userIfaceName;
+};
+
+LogindPathInternal::LogindPathInternal()
+{
+    qRegisterMetaType<NamedSeatPath>("NamedSeatPath");
+    qDBusRegisterMetaType<NamedSeatPath>();
+
+    qRegisterMetaType<NamedSeatPathList>("NamedSeatPathList");
+    qDBusRegisterMetaType<NamedSeatPathList>();
+
+    qRegisterMetaType<NamedSessionPath>("NamedSessionPath");
+    qDBusRegisterMetaType<NamedSessionPath>();
+
+    qRegisterMetaType<NamedSessionPathList>("NamedSessionPathList");
+    qDBusRegisterMetaType<NamedSessionPathList>();
+
+    qRegisterMetaType<SessionInfo>("SessionInfo");
+    qDBusRegisterMetaType<SessionInfo>();
+
+    qRegisterMetaType<SessionInfoList>("SessionInfoList");
+    qDBusRegisterMetaType<SessionInfoList>();
+
+    qRegisterMetaType<UserInfo>("UserInfo");
+    qDBusRegisterMetaType<UserInfo>();
+
+    qRegisterMetaType<UserInfoList>("UserInfoList");
+    qDBusRegisterMetaType<UserInfoList>();
+
+    if (QDBusConnection::systemBus().interface()->isServiceRegistered(
+            QStringLiteral("org.freedesktop.login1"))) {
+        qDebug() << "Logind interface found";
+        available = true;
+        serviceName = QStringLiteral("org.freedesktop.login1");
+        managerPath = QStringLiteral("/org/freedesktop/login1");
+        managerIfaceName = QStringLiteral("org.freedesktop.login1.Manager");
+        seatIfaceName = QStringLiteral("org.freedesktop.login1.Seat");
+        sessionIfaceName = QStringLiteral("org.freedesktop.login1.Session");
+        userIfaceName = QStringLiteral("org.freedesktop.login1.User");
+        return;
+    }
+
+    if (QDBusConnection::systemBus().interface()->isServiceRegistered(
+            QStringLiteral("org.freedesktop.ConsoleKit"))) {
+        qDebug() << "Console kit interface found";
+        available = true;
+        serviceName = QStringLiteral("org.freedesktop.ConsoleKit");
+        managerPath = QStringLiteral("/org/freedesktop/ConsoleKit/Manager");
+        managerIfaceName =
+            QStringLiteral("org.freedesktop.ConsoleKit.Manager"); // note this doesn't match logind
+        seatIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Seat");
+        sessionIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Session");
+        userIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.User");
+        return;
+    }
+    qDebug() << "No session manager found";
+}
+
+Q_GLOBAL_STATIC(LogindPathInternal, s_instance);
+
+bool Logind::isAvailable()
+{
+    return s_instance->available;
+}
+
+QString Logind::serviceName()
+{
+    return s_instance->serviceName;
+}
+
+QString Logind::managerPath()
+{
+    return s_instance->managerPath;
+}
+
+QString Logind::managerIfaceName()
+{
+    return s_instance->managerIfaceName;
+}
+
+QString Logind::seatIfaceName()
+{
+    return s_instance->seatIfaceName;
+}
+
+QString Logind::sessionIfaceName()
+{
+    return s_instance->sessionIfaceName;
+}
+
+QString Logind::userIfaceName()
+{
+    return s_instance->userIfaceName;
+}

--- a/src/utils/loginddbustypes.h
+++ b/src/utils/loginddbustypes.h
@@ -1,0 +1,193 @@
+#ifndef LOGIND_DBUSTYPES
+#define LOGIND_DBUSTYPES
+
+#include <QDBusArgument>
+#include <QDBusObjectPath>
+
+struct Logind
+{
+    static bool isAvailable();
+    static QString serviceName();
+    static QString managerPath();
+    static QString managerIfaceName();
+    static QString sessionIfaceName();
+    static QString seatIfaceName();
+    static QString userIfaceName();
+};
+
+struct SessionInfo
+{
+    QString sessionId;
+    uint userId;
+    QString userName;
+    QString seatId;
+    QDBusObjectPath sessionPath;
+};
+
+typedef QList<SessionInfo> SessionInfoList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const SessionInfo &sessionInfo)
+{
+    argument.beginStructure();
+    argument << sessionInfo.sessionId;
+    argument << sessionInfo.userId;
+    argument << sessionInfo.userName;
+    argument << sessionInfo.seatId;
+    argument << sessionInfo.sessionPath;
+    argument.endStructure();
+
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, SessionInfo &sessionInfo)
+{
+    argument.beginStructure();
+    argument >> sessionInfo.sessionId;
+    argument >> sessionInfo.userId;
+    argument >> sessionInfo.userName;
+    argument >> sessionInfo.seatId;
+    argument >> sessionInfo.sessionPath;
+    argument.endStructure();
+
+    return argument;
+}
+
+struct UserInfo
+{
+    uint userId;
+    QString name;
+    QDBusObjectPath path;
+};
+
+typedef QList<UserInfo> UserInfoList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const UserInfo &userInfo)
+{
+    argument.beginStructure();
+    argument << userInfo.userId;
+    argument << userInfo.name;
+    argument << userInfo.path;
+    argument.endStructure();
+
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, UserInfo &userInfo)
+{
+    argument.beginStructure();
+    argument >> userInfo.userId;
+    argument >> userInfo.name;
+    argument >> userInfo.path;
+    argument.endStructure();
+
+    return argument;
+}
+
+struct NamedSeatPath
+{
+    QString name;
+    QDBusObjectPath path;
+};
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const NamedSeatPath &namedSeat)
+{
+    argument.beginStructure();
+    argument << namedSeat.name;
+    argument << namedSeat.path;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, NamedSeatPath &namedSeat)
+{
+    argument.beginStructure();
+    argument >> namedSeat.name;
+    argument >> namedSeat.path;
+    argument.endStructure();
+    return argument;
+}
+
+typedef QList<NamedSeatPath> NamedSeatPathList;
+
+typedef NamedSeatPath NamedSessionPath;
+typedef NamedSeatPathList NamedSessionPathList;
+
+class NamedUserPath
+{
+public:
+    uint userId;
+    QDBusObjectPath path;
+};
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const NamedUserPath &namedUser)
+{
+    argument.beginStructure();
+    argument << namedUser.userId;
+    argument << namedUser.path;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, NamedUserPath &namedUser)
+{
+    argument.beginStructure();
+    argument >> namedUser.userId;
+    argument >> namedUser.path;
+    argument.endStructure();
+    return argument;
+}
+
+class Inhibitor
+{
+public:
+    QString what;
+    QString who;
+    QString why;
+    QString mode;
+    int userId;
+    uint processId;
+};
+
+typedef QList<Inhibitor> InhibitorList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const Inhibitor &inhibitor)
+{
+    argument.beginStructure();
+    argument << inhibitor.what;
+    argument << inhibitor.who;
+    argument << inhibitor.why;
+    argument << inhibitor.mode;
+    argument << inhibitor.userId;
+    argument << inhibitor.processId;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, Inhibitor &inhibitor)
+{
+    argument.beginStructure();
+    argument >> inhibitor.what;
+    argument >> inhibitor.who;
+    argument >> inhibitor.why;
+    argument >> inhibitor.mode;
+    argument >> inhibitor.userId;
+    argument >> inhibitor.processId;
+    argument.endStructure();
+    return argument;
+}
+
+Q_DECLARE_METATYPE(SessionInfo);
+Q_DECLARE_METATYPE(QList<SessionInfo>);
+
+Q_DECLARE_METATYPE(UserInfo);
+Q_DECLARE_METATYPE(QList<UserInfo>);
+
+Q_DECLARE_METATYPE(NamedSeatPath);
+Q_DECLARE_METATYPE(QList<NamedSeatPath>);
+
+Q_DECLARE_METATYPE(NamedUserPath);
+
+Q_DECLARE_METATYPE(Inhibitor);
+Q_DECLARE_METATYPE(QList<Inhibitor>);
+
+#endif


### PR DESCRIPTION
This modification has multiple benefits. DM and the synthesizer will become two independent parts. If one of them crashes, it will not cause a large-scale component crash.

DM should also delegate the user's session to systemd for management in the future, so that if any of the three parts crash, they can rely on crash recovery to restart.

By the way, DDE users will not have sessions, so the pulseaudio service will not be started in advance on deepin, and the file permissions of /dev/dri/renderD128 are set by logind using acl when activating the session. Now that dde is not a logged-in session, the activation relationship between normal users will be correct, and I hope that the sudden panic rhi rendering crash can be solved.

Log: