### PR TITLE
chore: mark uncreatable

### DIFF
--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -37,6 +37,7 @@ class Workspace : public SurfaceContainer
     Q_PROPERTY(WorkspaceAnimationController *animationController READ animationController CONSTANT FINAL)
     Q_PROPERTY(int count READ count NOTIFY countChanged FINAL)
     QML_ELEMENT
+    QML_UNCREATABLE("Created only in C++")
 
 public:
     explicit Workspace(SurfaceContainer *parent);

--- a/src/workspace/workspacemodel.h
+++ b/src/workspace/workspacemodel.h
@@ -21,6 +21,7 @@ class WorkspaceModel : public SurfaceListModel
     Q_PROPERTY(bool opaque READ opaque WRITE setOpaque NOTIFY opaqueChanged FINAL)
 
     QML_ELEMENT
+    QML_UNCREATABLE("Created only in C++")
 
 public:
     explicit WorkspaceModel(QObject *parent,


### PR DESCRIPTION
Mark Workspace and WorkspaceModel as uncreatable to suppress warnings.
